### PR TITLE
Longer Line Length

### DIFF
--- a/NocWorx/ruleset.xml
+++ b/NocWorx/ruleset.xml
@@ -59,7 +59,7 @@
 
   <rule ref="Generic.Files.LineLength">
     <properties>
-      <property name="absoluteLineLimit" value="79"/>
+      <property name="absoluteLineLimit" value="120"/>
       <property name="ignoreComments" value="false"/>
     </properties>
   </rule>

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 - Indent all block bodies one level (2 spaces)
 - Closing brace of any block is -2 spaces from the body's indention and on its own line (exceptions for `else`, `elseif`, `do-while`, and multiline function call/declaration)
 - Function calls or declarations needing multiple lines, follow indention guidelines for blocks. The opening brace for a declaration appears on the same line as the closing paranthesis.
-- Line length: 79 + \n
+- Line length: 120
 - Comments
   1. Use doc block style comments on each files, classes, functions, methods, and class properties
   - File doc block must include our legal template


### PR DESCRIPTION
fixes MAD-7310

this doesn't affect rules/conventions regarding multi-line statements, etc.; just moves the artifical limit which has proven to be too small.